### PR TITLE
Updated links to dexvis.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Dex : The data explorer is a data visualization tool written in Java/JavaFX capa
 
 ## Other Resources
 
-* [Main Site](http://dexvis.com)
+* [Main Site](http://dexvis.net)
 * [Blog](http://dexvis.wordpress.com)
 
 # Requirements
@@ -17,7 +17,7 @@ Dex : The data explorer is a data visualization tool written in Java/JavaFX capa
 
 There are 2 main ways to install Dex.
 
-1. [Download a stable release](http://dexvis.com/doku.php?id=Download)
+1. [Download a stable release](http://dexvis.net/doku.php?id=Download)
 2. Install via Git by following the instructions below.
 
 ## Via Git
@@ -43,55 +43,55 @@ The following are a small sample of the 50+ data visualizations Dex is capable o
 
 This visualization was created with Dex to visualize the relationships between Dr Who villans and motivations.
 
-<a href="http://dexvis.com/vis/blog/2016/feb/18/DrWho_Network.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/DrWho_D3Plus_Network.png" height="250"></a>
+<a href="http://dexvis.net/vis/blog/2016/feb/18/DrWho_Network.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/DrWho_D3Plus_Network.png" height="250"></a>
 
 ## Maps
 
 This visualization was created with Dex to visualize internet use across the world over the past 20 years.
 
-<a href="http://dexvis.com/vis/blog/2016/mar/03/Player_WDI_PercentInternetPlotly.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Player_WDI_InetUsePlotly.png" height="250"></a>
+<a href="http://dexvis.net/vis/blog/2016/mar/03/Player_WDI_PercentInternetPlotly.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Player_WDI_InetUsePlotly.png" height="250"></a>
 
 ## Time Visualizations
 
 This visualization depicts a small series over time.
 
-<a href="http://dexvis.com/vis/blog/2016/mar/01/examples/ui/Player1.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Player1Demo.png" height="250"></a>
+<a href="http://dexvis.net/vis/blog/2016/mar/01/examples/ui/Player1.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Player1Demo.png" height="250"></a>
 
 This visualization depicts a more complex series over time.
 
-<a href="http://dexvis.com/vis/blog/2016/mar/01/examples/ui/Player2.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Player2Demo.png" height="250"></a>
+<a href="http://dexvis.net/vis/blog/2016/mar/01/examples/ui/Player2.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Player2Demo.png" height="250"></a>
 
 ## Chord Visualizations
 
 This visualization depicts relationships via a Chord diagram over time.
 
-<a href="http://dexvis.com/vis/blog/2016/mar/01/examples/ui/PlayerChord.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/PlayerChordDemo.png" height="250"></a>
+<a href="http://dexvis.net/vis/blog/2016/mar/01/examples/ui/PlayerChord.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/PlayerChordDemo.png" height="250"></a>
 
 ## UML Visualizations
 
 A Class Diagram of the various battles within the Game of Thrones.
 
-<a href="http://dexvis.com/vis/blog/2016/feb/18/UML_Thrones_Class.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Thrones_UML_ClassDiagram.png" height="250"></a>
+<a href="http://dexvis.net/vis/blog/2016/feb/18/UML_Thrones_Class.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Thrones_UML_ClassDiagram.png" height="250"></a>
 
 A Sequence Diagram of the various battles within the Game of Thrones.
 
-<a href="http://dexvis.com/vis/blog/2016/feb/18/UML_Thrones_Seq.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Thrones_UML_Sequence.png" height="250"></a>
+<a href="http://dexvis.net/vis/blog/2016/feb/18/UML_Thrones_Seq.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Thrones_UML_Sequence.png" height="250"></a>
 
 ## Network Visualizations
 
 A large network comprised of every word spoken by Donald trump connected by the next word within the Iowa speech.  This network visualization is founded on the high performance VivaGraph.
 
-<a href="http://dexvis.com/vis/blog/2016/feb/24/TrumpIowaSpeech.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/TrumpIowaSpeech.png" height="250"></a>
+<a href="http://dexvis.net/vis/blog/2016/feb/24/TrumpIowaSpeech.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/TrumpIowaSpeech.png" height="250"></a>
 
 A vis.js visualization of the battles between the various houses within the Game of Thrones.
 
-<a href="http://dexvis.com/vis/blog/2016/feb/18/Vis_Thrones.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Vis_Network_Thrones.png" height="250"></a>
+<a href="http://dexvis.net/vis/blog/2016/feb/18/Vis_Thrones.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/Vis_Network_Thrones.png" height="250"></a>
 
 ## Timelines
 
 A vis.js timeline visualization of the sequence of events that lead up to, and occurred during World War I.
 
-<a href="http://dexvis.com/vis/blog/2016/feb/18/Vis_WWI_Timeline.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/WWI_Timeline1.png" height="250"></a>
+<a href="http://dexvis.net/vis/blog/2016/feb/18/Vis_WWI_Timeline.html"><img src="https://raw.githubusercontent.com/PatMartin/Dex/master/images/github_docs/WWI_Timeline1.png" height="250"></a>
 
 ## 3D Graphs
 


### PR DESCRIPTION
Replaced old dexvis.com domain to dexvis.net.  It seems GoDaddy didn't auto-renew my domain and a domain squatter acquired it and pointed it to GoDaddy's cash parking site.  Apologies for any confusion. I have switched registrars..